### PR TITLE
feat: Add page limit before rejecting PDF files

### DIFF
--- a/crawl4ai/processors/pdf/__init__.py
+++ b/crawl4ai/processors/pdf/__init__.py
@@ -1,49 +1,53 @@
-from pathlib import Path
 import asyncio
 from dataclasses import asdict
-from crawl4ai.async_logger import AsyncLogger
+from pathlib import Path
+
 from crawl4ai.async_crawler_strategy import AsyncCrawlerStrategy
-from crawl4ai.models import AsyncCrawlResponse, ScrapingResult 
+from crawl4ai.async_logger import AsyncLogger
 from crawl4ai.content_scraping_strategy import ContentScrapingStrategy
+from crawl4ai.models import AsyncCrawlResponse, ScrapingResult
+
 from .processor import NaivePDFProcessorStrategy  # Assuming your current PDF code is in pdf_processor.py
+
 
 class PDFCrawlerStrategy(AsyncCrawlerStrategy):
     def __init__(self, logger: AsyncLogger = None):
         self.logger = logger
-        
+
     async def crawl(self, url: str, **kwargs) -> AsyncCrawlResponse:
         # Just pass through with empty HTML - scraper will handle actual processing
         return AsyncCrawlResponse(
             html="Scraper will handle the real work",  # Scraper will handle the real work
             response_headers={"Content-Type": "application/pdf"},
-            status_code=200
+            status_code=200,
         )
-    
+
     async def close(self):
-        pass        
-        
-    async def __aenter__(self):        
+        pass
+
+    async def __aenter__(self):
         return self
-    
+
     async def __aexit__(self, exc_type, exc_val, exc_tb):
         await self.close()
+
 
 class PDFContentScrapingStrategy(ContentScrapingStrategy):
     """
     A content scraping strategy for PDF files.
-    
+
     Attributes:
         save_images_locally (bool): Whether to save images locally.
         extract_images (bool): Whether to extract images from PDF.
         image_save_dir (str): Directory to save extracted images.
         logger (AsyncLogger): Logger instance for recording events and errors.
-        
+
     Methods:
         scrap(url: str, html: str, **params) -> ScrapingResult:
             Scrap content from a PDF file.
         ascrap(url: str, html: str, **kwargs) -> ScrapingResult:
             Asynchronous version of scrap.
-            
+
     Usage:
         strategy = PDFContentScrapingStrategy(
             save_images_locally=False,
@@ -51,76 +55,110 @@ class PDFContentScrapingStrategy(ContentScrapingStrategy):
             image_save_dir=None,
             logger=logger
         )
-        
+
     """
-    def __init__(self, 
-                 save_images_locally : bool = False,
-                 extract_images : bool = False,
-                 image_save_dir : str = None,
-                 batch_size: int = 4,
-                 logger: AsyncLogger = None):
+
+    def __init__(
+        self,
+        save_images_locally: bool = False,
+        extract_images: bool = False,
+        image_save_dir: str = None,
+        batch_size: int = 4,
+        max_pages: int = None,
+        logger: AsyncLogger = None,
+    ):
         self.logger = logger
         self.pdf_processor = NaivePDFProcessorStrategy(
             save_images_locally=save_images_locally,
             extract_images=extract_images,
             image_save_dir=image_save_dir,
-            batch_size=batch_size
+            batch_size=batch_size,
         )
         self._temp_files = []  # Track temp files for cleanup
+        self.max_pages = max_pages
 
     def scrap(self, url: str, html: str, **params) -> ScrapingResult:
         """
         Scrap content from a PDF file.
-        
+
         Args:
             url (str): The URL of the PDF file.
             html (str): The HTML content of the page.
             **params: Additional parameters.
-        
+
         Returns:
             ScrapingResult: The scraped content.
         """
         # Download if URL or use local path
         pdf_path = self._get_pdf_path(url)
         try:
+            # Checkk page count before processing
+            page_count = self._get_page_count(Path(pdf_path))
+            if self.max_pages and page_count > self.max_pages:
+                if self.logger:
+                    self.logger.warning(f"Skipping PDF with {page_count} pages (max allowed: {self.max_pages})")
+
+                # Return minimal result for large PDFs
+                return ScrapingResult(
+                    cleaned_html=f"""
+                    <html>
+                        <head><meta name="pdf-pages" content="{page_count}"></head>
+                        <body>
+                            <div class="pdf-skipped">
+                            <h2>PDF Skipped - Too Many Pages</h2>
+                                <p>PDF has {page_count} pages, but max allowed is {self.max_pages}.</p>
+                                <p>Skipped to prevent processing timeout.</p>
+                            </div>
+                        </body>
+                    </html>
+                    """,
+                    success=True,
+                    media={"images": []},
+                    links={"urls": []},
+                    metadata={
+                        "pages": page_count,
+                        "skipped": True,
+                        "reason": f"Too many pages ({page_count} > {self.max_pages})",
+                    },
+                )
+            if self.logger:
+                self.logger.info(f"Processing PDF with {page_count} pages")
+
             # Process PDF
             # result = self.pdf_processor.process(Path(pdf_path))
             result = self.pdf_processor.process_batch(Path(pdf_path))
-            
+
             # Combine page HTML
             cleaned_html = f"""
         <html>
             <head><meta name="pdf-pages" content="{len(result.pages)}"></head>
             <body>
-                {''.join(f'<div class="pdf-page" data-page="{i+1}">{page.html}</div>'
-                         for i, page in enumerate(result.pages))}
+                {
+                "".join(
+                    f'<div class="pdf-page" data-page="{i + 1}">{page.html}</div>'
+                    for i, page in enumerate(result.pages)
+                )
+            }
             </body>
         </html>
         """
-            
+
             # Accumulate media and links with page numbers
             media = {"images": []}
             links = {"urls": []}
-            
+
             for page in result.pages:
                 # Add page number to each image
                 for img in page.images:
                     img["page"] = page.page_number
                     media["images"].append(img)
-                
+
                 # Add page number to each link
                 for link in page.links:
-                    links["urls"].append({
-                        "url": link,
-                        "page": page.page_number
-                    })
+                    links["urls"].append({"url": link, "page": page.page_number})
 
             return ScrapingResult(
-                cleaned_html=cleaned_html,
-                success=True,
-                media=media,
-                links=links,
-                metadata=asdict(result.metadata)
+                cleaned_html=cleaned_html, success=True, media=media, links=links, metadata=asdict(result.metadata)
             )
         finally:
             # Cleanup temp file if downloaded
@@ -136,32 +174,32 @@ class PDFContentScrapingStrategy(ContentScrapingStrategy):
     async def ascrap(self, url: str, html: str, **kwargs) -> ScrapingResult:
         # For simple cases, you can use the sync version
         return await asyncio.to_thread(self.scrap, url, html, **kwargs)
-        
 
     def _get_pdf_path(self, url: str) -> str:
         if url.startswith(("http://", "https://")):
             import tempfile
+
             import requests
-            
+
             # Create temp file with .pdf extension
-            temp_file = tempfile.NamedTemporaryFile(suffix='.pdf', delete=False)
+            temp_file = tempfile.NamedTemporaryFile(suffix=".pdf", delete=False)
             self._temp_files.append(temp_file.name)
-            
+
             try:
                 if self.logger:
                     self.logger.info(f"Downloading PDF from {url}...")
-                
+
                 # Download PDF with streaming and timeout
                 # Connection timeout: 10s, Read timeout: 300s (5 minutes for large PDFs)
                 response = requests.get(url, stream=True, timeout=(20, 60 * 10))
                 response.raise_for_status()
-                
+
                 # Get file size if available
-                total_size = int(response.headers.get('content-length', 0))
+                total_size = int(response.headers.get("content-length", 0))
                 downloaded = 0
-                
+
                 # Write to temp file
-                with open(temp_file.name, 'wb') as f:
+                with open(temp_file.name, "wb") as f:
                     for chunk in response.iter_content(chunk_size=8192):
                         f.write(chunk)
                         downloaded += len(chunk)
@@ -169,12 +207,12 @@ class PDFContentScrapingStrategy(ContentScrapingStrategy):
                             progress = (downloaded / total_size) * 100
                             if progress % 10 < 0.1:  # Log every 10%
                                 self.logger.debug(f"PDF download progress: {progress:.0f}%")
-                
+
                 if self.logger:
                     self.logger.info(f"PDF downloaded successfully: {temp_file.name}")
-                        
+
                 return temp_file.name
-                
+
             except requests.exceptions.Timeout as e:
                 # Clean up temp file if download fails
                 Path(temp_file.name).unlink(missing_ok=True)
@@ -185,11 +223,27 @@ class PDFContentScrapingStrategy(ContentScrapingStrategy):
                 Path(temp_file.name).unlink(missing_ok=True)
                 self._temp_files.remove(temp_file.name)
                 raise RuntimeError(f"Failed to download PDF from {url}: {str(e)}")
-                
+
         elif url.startswith("file://"):
             return url[7:]  # Strip file:// prefix
-            
+
         return url  # Assume local path
-    
+
+    def _get_page_count(self, pdf_path: Path) -> int:
+        """
+        Gets page count without processing the PDF
+        """
+        try:
+            from PyPDF2 import PdfReader
+
+            with pdf_path.open("rb") as f:
+                reader = PdfReader(f)
+                return len(reader.pages)
+        except Exception as e:
+            if self.logger:
+                self.logger.error(f"Failed to get page count for {pdf_path}: {str(e)}")
+            # Assume too big if cannot get page count
+            return self.max_pages + 1
+
 
 __all__ = ["PDFCrawlerStrategy", "PDFContentScrapingStrategy"]

--- a/deploy/docker/README.md
+++ b/deploy/docker/README.md
@@ -710,6 +710,7 @@ security:
 # Crawler Configuration
 crawler:
   memory_threshold_percent: 95.0
+  max_pages: 15 #Max number of pages in PDF before rejected
   rate_limiter:
     base_delay: [1.0, 2.0] # Min/max delay between requests in seconds for dispatcher
   timeouts:

--- a/deploy/docker/config_headed.yml
+++ b/deploy/docker/config_headed.yml
@@ -54,6 +54,7 @@ crawler:
   base_config:
     simulate_user: true
   memory_threshold_percent: 95.0
+  max_pages: 15
   rate_limiter:
     enabled: true
     base_delay: [1.0, 2.0]

--- a/deploy/docker/config_headless.yml
+++ b/deploy/docker/config_headless.yml
@@ -54,6 +54,7 @@ crawler:
   base_config:
     simulate_user: true
   memory_threshold_percent: 95.0
+  max_pages: 15
   rate_limiter:
     enabled: true
     base_delay: [1.0, 2.0]


### PR DESCRIPTION
## Summary
Added a functionality to the config and pdf processor to cap number of pdf pages script, else it will discard the pdf

## List of files changed and why
deploy/docker/api.py - Added logic to take `max_pages` parameter from config and send that to `PDFContentScrapingStrategy`
crawl4ai/processor/pdf/__init__.py -  Added logic to count number of pages and reject if num > `max_pages`
config_headed/headless.yml - Added max_pages into crawler config
README.md - Added documentation for new config parameter

PS: Some line changes caused by ruff format
For quick check: 
- Check 164-167 on deploy/docker/api.py
- Check 95-126, 232-246 on crawl4ai/processor/pdf/__init__.py

## How Has This Been Tested?
Ran Jan Nano on SimpleQA with both Serper API and Crawl4AI's visit tool, able to run through entire SimpleQA, as well as handle 400-600 page long PDFs
